### PR TITLE
Support ranges and inclusion tests

### DIFF
--- a/Rel8.hs
+++ b/Rel8.hs
@@ -88,6 +88,9 @@ module Rel8
   , (||?), (&&?), (+?), (*?), (-?)
   , (/?)
 
+    -- ** Inclusion predicate operators
+  , DBContains, (<@.), (@>.)
+
     -- * Running Queries
     -- ** @SELECT@
   , select

--- a/Rel8/Internal/DBType.hs
+++ b/Rel8/Internal/DBType.hs
@@ -36,6 +36,7 @@ import Data.Typeable (Typeable)
 import Data.UUID (UUID)
 import Data.Vector (Vector)
 import Database.PostgreSQL.Simple.FromField (FromField)
+import qualified Database.PostgreSQL.Simple.Range as PGSR
 import Generics.OneLiner (ADT, Constraints, gfoldMap)
 import qualified Opaleye.Column as O
 import qualified Opaleye.Internal.Column as O
@@ -155,6 +156,21 @@ instance DBType Scientific where
 -- | json
 instance DBType Value where
   dbTypeInfo = typeInfoFromOpaleye O.pgValueJSON
+
+instance DBType (PGSR.PGRange UTCTime) where
+  dbTypeInfo = typeInfoFromOpaleye $ \(PGSR.PGRange l r) -> O.pgRange O.pgUTCTime l r
+
+instance DBType (PGSR.PGRange LocalTime) where
+  dbTypeInfo = typeInfoFromOpaleye $ \(PGSR.PGRange l r) -> O.pgRange O.pgLocalTime l r
+
+instance DBType (PGSR.PGRange Day) where
+  dbTypeInfo = typeInfoFromOpaleye $ \(PGSR.PGRange l r) -> O.pgRange O.pgDay l r
+
+instance DBType (PGSR.PGRange Int) where
+  dbTypeInfo = typeInfoFromOpaleye $ \(PGSR.PGRange l r) -> O.pgRange O.pgInt4 l r
+
+instance DBType (PGSR.PGRange Int64) where
+  dbTypeInfo = typeInfoFromOpaleye $ \(PGSR.PGRange l r) -> O.pgRange O.pgInt8 l r
 
 instance (DBType a, Typeable a) =>
          DBType (Vector a) where

--- a/Rel8/Internal/Operators.hs
+++ b/Rel8/Internal/Operators.hs
@@ -8,7 +8,8 @@ module Rel8.Internal.Operators where
 
 import Data.Int (Int16, Int32, Int64)
 import Data.Text (Text)
-import Data.Time (UTCTime)
+import Data.Time (UTCTime, LocalTime, Day)
+import qualified Database.PostgreSQL.Simple.Range as PGSR
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as O
 import qualified Opaleye.Operators as O
 import qualified Opaleye.PGTypes as O
@@ -69,6 +70,11 @@ instance DBEq Int32 where
 instance DBEq Int64 where
 instance DBEq Text where
 instance DBEq UTCTime where
+instance DBEq (PGSR.PGRange UTCTime) where
+instance DBEq (PGSR.PGRange LocalTime) where
+instance DBEq (PGSR.PGRange Day) where
+instance DBEq (PGSR.PGRange Int) where
+instance DBEq (PGSR.PGRange Int64) where
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This adds `DBType` instances for ranges.

I've also added a class `DBContains` for Postgres's inclusion test operators `<@`/`@>`, which are pretty [heavily overloaded](https://stackoverflow.com/a/36986048/4309055). I mainly only need them to check if a date is in a date range. More instances could be added, particularly if there was a `JSONB` type.

This part could be approached in a few different ways. One might argue we should not have a type class that could do everything the postgres operators do, but rather only have a class focused on ranges. My inclination was to start with this class, and then if someone needs other range operations they could add a range class as a subclass. 