### PR TITLE
Support for representing insert-values in haskell

### DIFF
--- a/Rel8.hs
+++ b/Rel8.hs
@@ -93,7 +93,7 @@ module Rel8
   , select
 
     -- ** @INSERT@
-  , Default(..), Insert
+  , Default(..), Insert, In
   , insert, insert1Returning {- , insertReturning -}
 
     -- ** @UPDATE@

--- a/Rel8/Internal/Types.hs
+++ b/Rel8/Internal/Types.hs
@@ -24,6 +24,12 @@ data Insert a = InsertExpr (Expr a)
 
 
 --------------------------------------------------------------------------------
+-- | Interpret a 'Table' as Haskell values to be inserted. If columns are marked as
+-- having a default value, it will be possible to use 'Default' instead of
+-- supplying a value.
+data In a
+
+--------------------------------------------------------------------------------
 -- | Used internal to reflect the schema of a table from types into values.
 data SchemaInfo a =
   SchemaInfo String
@@ -41,6 +47,7 @@ data SchemaInfo a =
 data Default a
   = OverrideDefault a
   | InsertDefault
+  deriving Show
 
 --------------------------------------------------------------------------------
 {-| All metadata about a column in a table.
@@ -61,6 +68,8 @@ type family C f columnName hasDefault columnType :: * where
   C SchemaInfo name hasDefault t = SchemaInfo '(name, hasDefault, t)
   C Insert name 'HasDefault t = Default (Expr t)
   C Insert name 'NoDefault t = Expr t
+  C In name 'HasDefault t = Default t
+  C In name 'NoDefault t = t
   C Aggregate name _ t = Aggregate t
 
 -- | @Anon@ can be used to define columns like 'C', but does not contain the


### PR DESCRIPTION
This was a convenience I found to be pretty Indispensable, and I can't see any downside.

In general I want a way to represent my record I'll be inserting on the Haskell side without having to supply dummy values for things like keys or timestamps that will just be overwritten. 

This would affect #11 as something with this type parameter will be isomorphic to the `Insert` version, and thus converting between them would be more natural.

Open to bikeshedding on the name...


