### PR TITLE
Remove MonadMask for PostgreSQLTransactionT

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 , exceptions, free, lens, monad-control, mtl, one-liner, opaleye
 , postgresql-simple, profunctors, resourcet, scientific, stdenv
 , streaming, streaming-postgresql-simple, tagged, text, time
-, transformers, uuid, vector
+, transformers, unliftio, uuid, vector
 }:
 mkDerivation {
   pname = "rel8";
@@ -12,10 +12,10 @@ mkDerivation {
     adjunctions aeson base bytestring contravariant exceptions free
     lens monad-control mtl one-liner opaleye postgresql-simple
     profunctors resourcet scientific streaming
-    streaming-postgresql-simple tagged text time transformers uuid
-    vector
+    streaming-postgresql-simple tagged text time transformers unliftio
+    uuid vector
   ];
   testHaskellDepends = [ base ];
-  description = "A type-safe, expressive and concise API for querying relational databases using Opaleye";
+  description = "A type-safe, expressive and concise API for querying relational databases";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -65,6 +65,7 @@ library
                      , text
                      , time
                      , transformers
+                     , unliftio >= 0.2.7.0 && < 0.3
                      , uuid
                      , vector
                      , lens


### PR DESCRIPTION
Remove the requirement for MonadMask from the MonadTransaction instance
of PostgreSQLTransactionT since it already has a MonadUnliftIO
constraint.